### PR TITLE
squash runtime warning about mean of empty slice

### DIFF
--- a/networkml/utils/model.py
+++ b/networkml/utils/model.py
@@ -339,7 +339,11 @@ class Model:
                 if (tp + fn) > 0:
                     self.logger.info('F1 of {} for {}'.format(f1, label))
 
-        self.logger.info('Mean F1: {}'.format(np.mean(f1s)))
+        ## Check if f1s list is empty to avoid calculating mean of empty list
+        if not f1s:
+            self.logger.info('Mean F1: {}'.format("Empty list--no F1 scores available"))
+        else:
+            self.logger.info('Mean F1: {}'.format(np.mean(f1s)))
 
     def classify_representation(self, representation):
         '''


### PR DESCRIPTION
Squash "RuntimeWarning: Mean of empty slice" being caused by unit test at tests/test_networkml.py::test_networkml_test_randomforest. networkML was trying to compute the mean of an empty list, which produced this warning.