### PR TITLE
Discard payload from packetizer().

### DIFF
--- a/networkml/parsers/pcap/reader.py
+++ b/networkml/parsers/pcap/reader.py
@@ -89,7 +89,6 @@ def packetizer(path):
             payload_offset = min(len(raw_packet) - transport_payload_size, 128)
             keys, highest_layers = head
             stripped_data = raw_packet[:payload_offset]
-            assert stripped_data
             packet_dict[keys] = binascii.hexlify(stripped_data).decode('utf-8')
             for key, highest_layer in highest_layers.items():
                 if key not in highest_layers_dict:

--- a/tests/test_pcap_reader.py
+++ b/tests/test_pcap_reader.py
@@ -21,12 +21,12 @@ def test_packetizer():
     # Migrate to UTC in the future.
     _, key1, key2 = head
     assert ('192.168.3.131:57011', '72.14.213.138:80') == (key1, key2)
-    assert 1994 == len(data)
+    assert 108 == len(data)
     assert '001a8c15f9804061' == data[:16]
     head, data = packet_list[-1]
     _, key1, key2 = head
     assert ('192.168.3.131:17500', '192.168.3.255:17500') == (key1, key2)
-    assert 324 == len(data)
+    assert 68 == len(data)
     assert 'ffffffffffff4061' == data[:16]
 
 


### PR DESCRIPTION
Drop packet payload beyond transport layer from packetizer() (isn't used by ML model anyway, and tshark will do the protocol detection for us anyway).

