### PR TITLE
Use scapy rather than IPv4-only constant offsets to parse IP packets.

### DIFF
--- a/networkml/parsers/pcap/pcap_utils.py
+++ b/networkml/parsers/pcap/pcap_utils.py
@@ -191,8 +191,8 @@ def extract_protocol(session):
     Returns:
         protocol: Protocol number used in the session
     '''
-
-    return session[0][1][46:48]
+    ip_packet = parse_ip_packet(session[0][1])
+    return ip_packet.proto
 
 
 def is_external(address_1, address_2):

--- a/networkml/parsers/pcap/pcap_utils.py
+++ b/networkml/parsers/pcap/pcap_utils.py
@@ -7,8 +7,11 @@ from collections import Counter
 from collections import defaultdict
 from collections import OrderedDict
 from scapy.layers.l2 import Ether
-from scapy.layers.inet import IP
-from scapy.layers.inet6 import IPv6
+from scapy.layers.inet import IP, ICMP
+# TODO: IPv6 disabled for now.
+# from scapy.layers.inet6 import IPv6
+
+LAYERS = (IP, ICMP)
 
 
 def parse_packet(packet):
@@ -20,7 +23,7 @@ def parse_packet(packet):
 
 def parse_ip_packet(packet):
     ether = parse_packet(packet)
-    for transport in IP, IPv6:
+    for transport in LAYERS:
         try:
             return ether[transport]
         except (IndexError, AttributeError):
@@ -192,7 +195,10 @@ def extract_protocol(session):
         protocol: Protocol number used in the session
     '''
     ip_packet = parse_ip_packet(session[0][1])
-    return ip_packet.proto
+    if ip_packet is not None:
+        # TODO: return as a string for compatibility, but should just be an int.
+        return '%2.2u' % ip_packet.proto
+    return None
 
 
 def is_external(address_1, address_2):

--- a/networkml/parsers/pcap/pcap_utils.py
+++ b/networkml/parsers/pcap/pcap_utils.py
@@ -6,6 +6,7 @@ import os
 from collections import Counter
 from collections import defaultdict
 from collections import OrderedDict
+import netaddr
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP, ICMP
 # TODO: IPv6 disabled for now.
@@ -46,6 +47,17 @@ def is_private(address):
         except ValueError:
             return False
     return address.is_private
+
+
+def mac_from_int(mac_int):
+    '''
+    Return Unix format MAC address from an integer.
+    Args:
+        mac_int: MAC address as integer.
+    Returns:
+        MAC address as Unix string format (fully expanded and lowercase).
+    '''
+    return str(netaddr.EUI(mac_int, dialect=netaddr.mac_unix_expanded)).lower()
 
 
 def extract_macs(packet):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pytest==5.3.4
 pytest-cov==2.8.1
 pytest-xdist==1.31.0
 redis==3.3.11
+scapy==2.4.3
 scikit-learn==0.22
 tensorflow==2.1.0

--- a/tests/test_utils_pcap_utils.py
+++ b/tests/test_utils_pcap_utils.py
@@ -1,3 +1,4 @@
+from scapy.layers.inet import IP
 from networkml.parsers.pcap.pcap_utils import extract_macs
 from networkml.parsers.pcap.pcap_utils import extract_protocol
 from networkml.parsers.pcap.pcap_utils import extract_session_size
@@ -5,6 +6,11 @@ from networkml.parsers.pcap.pcap_utils import is_external
 from networkml.parsers.pcap.pcap_utils import is_private
 from networkml.parsers.pcap.pcap_utils import is_protocol
 from networkml.parsers.pcap.pcap_utils import packet_size
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP, TCP
+
+
+TEST_IP_DATA = bytes(Ether()/IP(len=99,proto=6)/TCP()).hex()
 
 
 def test_extract_macs():
@@ -42,21 +48,21 @@ def test_is_private():
 
 
 def test_packet_size():
-    packet = ['0', '1234567890123456789012345678901234567890']
+    packet = ['0', TEST_IP_DATA]
     size = packet_size(packet)
-    assert size == 13398
+    assert size == 99
 
 
 def test_extract_session_size():
-    session = [['0', '1234567890123456789012345678901234567890']]
+    session = [['0', TEST_IP_DATA]]
     session_size = extract_session_size(session)
-    assert session_size == 13398
+    assert session_size == 99
 
 
 def test_extract_protocol():
-    session = [['0', '12345678901234567890123456789012345678901234567890']]
+    session = [['0', TEST_IP_DATA]]
     protocol = extract_protocol(session)
-    assert protocol == '78'
+    assert protocol == '06'
 
 
 def test_is_external():
@@ -67,8 +73,8 @@ def test_is_external():
 
 
 def test_is_protocol():
-    session = [['0', '12345678901234567890123456789012345678901234567890']]
-    protocol = is_protocol(session, '78')
+    session = [['0', TEST_IP_DATA]]
+    protocol = is_protocol(session, '06')
     assert protocol == True
-    protocol = is_protocol(session, 78)
+    protocol = is_protocol(session, 6)
     assert protocol == False


### PR DESCRIPTION
IPv6 is not yet enabled, but this will allow it to be easily enabled.
