### PR TITLE
Handle Poseidon trace files that don't have client/server in the name.

### DIFF
--- a/networkml/algorithms/base.py
+++ b/networkml/algorithms/base.py
@@ -90,11 +90,15 @@ class BaseAlgorithm:
         pcap_key = None
         pcap_labels = None
         if base_pcap.startswith('trace_'):
-            pcap_re = re.compile(r'^trace_([\da-f]+)_.+(client|server)-(.+).pcap$')
-            pcap_match = pcap_re.match(base_pcap)
-            if pcap_match:
-                pcap_key = pcap_match.group(1)
-                pcap_labels = pcap_match.group(3)
+            for pcap_re, key_pos, label_pos in (
+                    (re.compile(r'^trace_([\da-f]+)_([0-9\_\-]+)-(client|server)-(.+).pcap$'), 1, 4),
+                    (re.compile(r'^trace_([\da-f]+)_([0-9\_\-]+).pcap$'), 1, None)):
+                pcap_match = pcap_re.match(base_pcap)
+                if pcap_match:
+                    pcap_key = pcap_match.group(key_pos)
+                    if label_pos:
+                        pcap_labels = pcap_match.group(label_pos)
+                    break
         else:
             # Not a Poseidon trace file, return basename as key.
             pcap_key = base_pcap.split('.')[0]
@@ -166,7 +170,7 @@ class BaseAlgorithm:
             base_pcap = os.path.basename(fi)
             pcap_key, pcap_labels = self.parse_pcap_name(base_pcap)
             if pcap_key is None:
-                self.logger.debug('Ignoring unknown pcap name %s', base_pcap)
+                self.logger.warn('Ignoring unknown pcap name %s', base_pcap)
                 continue
 
             ## Get representations from the model

--- a/tests/test_basealgorithm.py
+++ b/tests/test_basealgorithm.py
@@ -16,6 +16,10 @@ def test_parse_pcap_name():
         None, None)
     assert parse_pcap_name('trace_ab12_2001-01-01_02_03-client-ip-1-2-3-4.pcap') == (
         'ab12', 'ip-1-2-3-4')
+    assert parse_pcap_name('trace_8adfcc152604e75d37a1a2ac62124ae859105239_2020-01-21_21_31_44-client-ip-17-253-66-125-17-253-66-125-192-168-3-2-udp-frame-ntp-wsshort-ip-eth-port-123.pcap') == (
+        '8adfcc152604e75d37a1a2ac62124ae859105239', 'ip-17-253-66-125-17-253-66-125-192-168-3-2-udp-frame-ntp-wsshort-ip-eth-port-123')
+    assert parse_pcap_name('trace_8198b3326dcb032a2bfbb8030339ff2159b9993d_2020-02-19_03_16_21.pcap') == (
+        '8198b3326dcb032a2bfbb8030339ff2159b9993d', None)
     assert parse_pcap_name('trace_ab12_2001-01-01_02_03-miscellaneous-stuff.pcap') == (
         None, None)
 


### PR DESCRIPTION
Log a warning (not debug message) when given an unknown pcap format.