### PR TITLE
Move to numpy (smaller in memory arrays for float fields).

### DIFF
--- a/networkml/featurizers/csv_to_features.py
+++ b/networkml/featurizers/csv_to_features.py
@@ -125,7 +125,7 @@ class CSVToFeatures():
     @staticmethod
     def get_rows(in_file, use_gzip):
         with CSVToFeatures.get_reader(in_file, use_gzip) as f_in:
-            return [CSVToFeatures.row_filter(line) for line in csv.DictReader(f_in)]
+            return tuple(CSVToFeatures.row_filter(line) for line in csv.DictReader(f_in))
 
     @staticmethod
     def parse_args(raw_args=None):

--- a/networkml/featurizers/features.py
+++ b/networkml/featurizers/features.py
@@ -1,9 +1,12 @@
 import functools
 import ipaddress
-import statistics
+import numpy
 
 
 class Features():
+
+    def __init__(self):
+        self.nonempty_generators = set()
 
     def run_func(self, func_name, *args):
         """
@@ -25,17 +28,19 @@ class Features():
         new_rows = [{field: row[field] for field in fields if row.get(field, None)} for row in rows]
         return new_rows
 
-    @staticmethod
     @functools.lru_cache()
-    def get_float_field(field, rows):
-        return [float(row[field]) for row in filter(lambda row: field in row, rows)]
+    def get_float_field(self, field, rows_f):
+        vals = numpy.fromiter((float(row[field]) for row in filter(lambda row: field in row, rows_f())), dtype=numpy.float)
+        if len(vals):
+            self.nonempty_generators.add(rows_f)
+            return vals
+        # Ensure that we don't get a non empty generator.
+        assert rows_f not in self.nonempty_generators, field
+        return [0]
 
-    def _stat_row_field(self, statfunc, field, rows):
+    def _stat_row_field(self, statfunc, field, rows_f):
         # apply a statistical function, to all rows with a given field.
-        try:
-            return statfunc(self.get_float_field(field, rows))
-        except (IndexError, ValueError, statistics.StatisticsError):
-            return 0
+        return statfunc(self.get_float_field(field, rows_f))
 
     @staticmethod
     def _tshark_ipversions(rows):

--- a/networkml/featurizers/funcs/host.py
+++ b/networkml/featurizers/funcs/host.py
@@ -1,8 +1,7 @@
 import functools
 from collections import Counter, defaultdict
-import statistics
-from numpy import percentile
 import netaddr
+import numpy
 from networkml.featurizers.features import Features
 
 
@@ -18,14 +17,14 @@ class HostBase:
 
     NAME_TO_STAT = {
         'count': len,
-        'max': max,
-        'min': min,
-        'average': statistics.mean,
-        'median': statistics.median,
-        'variance': statistics.variance,
-        '25q': lambda x: percentile(x, 25),
-        '75q': lambda x: percentile(x, 75),
-        'total': sum,
+        'max': numpy.max,
+        'min': numpy.min,
+        'average': numpy.mean,
+        'median': numpy.median,
+        'variance': numpy.var,
+        '25q': lambda x: numpy.percentile(x, 25),
+        '75q': lambda x: numpy.percentile(x, 75),
+        'total': numpy.sum,
     }
 
     # http://www.iana.org/assignments/protocol-numbers
@@ -37,6 +36,7 @@ class HostBase:
     WK_NONPRIV_PROTO_PORTS = frozenset(
         [1900, 2375, 2376, 5222, 5349, 5353, 5354, 5349, 5357, 6653])
     WK_PROTOS = frozenset(('tcp', 'udp', 'icmp', 'icmpv6', 'arp', 'other'))
+
 
     @staticmethod
     @functools.lru_cache(maxsize=65536)
@@ -77,16 +77,16 @@ class HostBase:
     def _select_mac_direction(self, rows_f, output=True, nodir=False):
         '''Return filter expression selecting input or output rows.'''
         if nodir:
-            return iter(rows_f())
+            return rows_f
         src_mac, all_macs = self._tshark_input_mac(rows_f)
         # Select all if can't infer direction.
         if src_mac is None or len(all_macs) == 1:
-            return iter(rows_f())
+            return rows_f
         if output:
             # Select all rows where traffic originated by inferred source MAC
-            return filter(lambda row: (row.get('eth.src', None) == src_mac), rows_f())
+            return lambda: filter(lambda row: (row.get('eth.src', None) == src_mac), rows_f())
         # Select all rows where traffic not originated by inferred source MAC.
-        return filter(lambda row: (row.get('eth.src', None) != src_mac), rows_f())
+        return lambda: filter(lambda row: (row.get('eth.src', None) != src_mac), rows_f())
 
     def _pyshark_ipversions(self, rows_f):
         ipversions = set()
@@ -221,11 +221,11 @@ class HostBase:
 
         return self._host_rows(rows_f, nonpriv_ports_present, all_rows_f=all_rows_f)
 
-    def _get_flags(self, rows, suffix, flags_field, decode_map):
+    def _get_flags(self, rows_f, suffix, flags_field, decode_map):
         flags_counter = Counter()
         for decoded_flag in decode_map.values():  # pytype: disable=attribute-error
             flags_counter[decoded_flag] = 0
-        for row in rows:
+        for row in rows_f():
             flags = self._safe_int(row.get(flags_field, 0))  # pytype: disable=attribute-error
             if flags:
                 for bit, decoded_flag in decode_map.items():
@@ -235,17 +235,17 @@ class HostBase:
             flags_field.replace('.', '_'), decoded_flag, suffix): val
                 for decoded_flag, val in flags_counter.items()}
 
-    def _get_tcp_flags(self, rows, suffix):
+    def _get_tcp_flags(self, rows_f, suffix):
         return self._get_flags(
-            rows, suffix, 'tcp.flags',
+            rows_f, suffix, 'tcp.flags',
             {0: 'fin', 1: 'syn', 2: 'rst', 3: 'psh', 4: 'ack', 5: 'urg', 6: 'ece', 7: 'cwr', 8: 'ns'})
 
-    def _get_ip_flags(self, rows, suffix):
+    def _get_ip_flags(self, rows_f, suffix):
         return self._get_flags(
-            rows, suffix, 'ip.flags', {13: 'rb', 14: 'df', 15: 'mf'})
+            rows_f, suffix, 'ip.flags', {13: 'rb', 14: 'df', 15: 'mf'})
 
-    def _get_ip_dsfield(self, rows, suffix):
-        return self._get_flags(rows, suffix, 'ip.dsfield', {
+    def _get_ip_dsfield(self, rows_f, suffix):
+        return self._get_flags(rows_f, suffix, 'ip.dsfield', {
             0: 'ecn0', 1: 'ecn1', 2: 'dscp0', 3: 'dscp1', 4: 'dscp2',
             5: 'dscp3', 6: 'dscp4', 7: 'dscp5'})
 
@@ -291,36 +291,36 @@ class HostBase:
         return self._host_rows(rows_f, lambda x: {'IPv6': int(6 in self._tshark_ipversions(x()))})
 
     def _tshark_priv_tcp_ports_in(self, rows_f):
-        in_rows = self._select_mac_direction(rows_f, output=False)
-        return self._get_priv_ports(lambda: in_rows, 'tcp', 'in', all_rows_f=rows_f)
+        in_rows_f = self._select_mac_direction(rows_f, output=False)
+        return self._get_priv_ports(in_rows_f, 'tcp', 'in', all_rows_f=rows_f)
 
     def _tshark_priv_tcp_ports_out(self, rows_f):
-        out_rows = self._select_mac_direction(rows_f, output=True)
-        return self._get_priv_ports(lambda: out_rows, 'tcp', 'out', all_rows_f=rows_f)
+        out_rows_f = self._select_mac_direction(rows_f, output=True)
+        return self._get_priv_ports(out_rows_f, 'tcp', 'out', all_rows_f=rows_f)
 
     def _tshark_priv_udp_ports_in(self, rows_f):
-        in_rows = self._select_mac_direction(rows_f, output=False)
-        return self._get_priv_ports(lambda: in_rows, 'udp', 'in', all_rows_f=rows_f)
+        in_rows_f = self._select_mac_direction(rows_f, output=False)
+        return self._get_priv_ports(in_rows_f, 'udp', 'in', all_rows_f=rows_f)
 
     def _tshark_priv_udp_ports_out(self, rows_f):
-        out_rows = self._select_mac_direction(rows_f, output=True)
-        return self._get_priv_ports(lambda: out_rows, 'udp', 'out', all_rows_f=rows_f)
+        out_rows_f = self._select_mac_direction(rows_f, output=True)
+        return self._get_priv_ports(out_rows_f, 'udp', 'out', all_rows_f=rows_f)
 
     def _tshark_nonpriv_tcp_ports_in(self, rows_f):
-        in_rows = self._select_mac_direction(rows_f, output=False)
-        return self._get_nonpriv_ports(lambda: in_rows, 'tcp', 'in', all_rows_f=rows_f)
+        in_rows_f = self._select_mac_direction(rows_f, output=False)
+        return self._get_nonpriv_ports(in_rows_f, 'tcp', 'in', all_rows_f=rows_f)
 
     def _tshark_nonpriv_tcp_ports_out(self, rows_f):
-        out_rows = self._select_mac_direction(rows_f, output=True)
-        return self._get_nonpriv_ports(lambda: out_rows, 'tcp', 'out', all_rows_f=rows_f)
+        out_rows_f = self._select_mac_direction(rows_f, output=True)
+        return self._get_nonpriv_ports(out_rows_f, 'tcp', 'out', all_rows_f=rows_f)
 
     def _tshark_nonpriv_udp_ports_in(self, rows_f):
-        in_rows = self._select_mac_direction(rows_f, output=False)
-        return self._get_nonpriv_ports(lambda: in_rows, 'udp', 'in', all_rows_f=rows_f)
+        in_rows_f = self._select_mac_direction(rows_f, output=False)
+        return self._get_nonpriv_ports(in_rows_f, 'udp', 'in', all_rows_f=rows_f)
 
     def _tshark_nonpriv_udp_ports_out(self, rows_f):
-        out_rows = self._select_mac_direction(rows_f, output=True)
-        return self._get_nonpriv_ports(lambda: out_rows, 'udp', 'out', all_rows_f=rows_f)
+        out_rows_f = self._select_mac_direction(rows_f, output=True)
+        return self._get_nonpriv_ports(out_rows_f, 'udp', 'out', all_rows_f=rows_f)
 
     def _tshark_tcp_flags_in(self, rows_f):
 
@@ -844,7 +844,7 @@ class SessionHost(HostBase, Features):
             }
         return {tuple([str(i) for i in key]) for key in keys}
 
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache()
     def _all_host_rows(self, rows_f, all_rows_f):
         all_keys = set()
         if all_rows_f is not None:

--- a/networkml/featurizers/main.py
+++ b/networkml/featurizers/main.py
@@ -67,10 +67,14 @@ class Featurizer():
             verify_feature_row(method, feature_row)
             return feature_row
 
+        # attempt to group methods together based on same field name for more cache hits.
+        def method_key(method):
+            return ''.join(reversed(method.strip('_in').strip('_out')))
+
         for f in classes:
             if groups:
                 methods = filter(lambda funcname: funcname.startswith(groups), dir(f[0]))
-                for method in methods:
+                for method in sorted(methods, key=method_key):
                     feature_rows.append(run_func(method, lambda: f[0].run_func(method, rows_f), f'{f[1]}/{method}'))
                     run_methods.append((f[1], method))
 

--- a/tests/test_featurizers_features.py
+++ b/tests/test_featurizers_features.py
@@ -13,5 +13,5 @@ def test_get_columns():
 
 def test_stat_row_field():
     instance = Features()
-    assert instance._stat_row_field(max, 'notthere', iter([{'foo': 1, 'baz': 3}])) == 0
-    assert instance._stat_row_field(max, 'foo', iter([{'foo': 1, 'baz': 3}, {'foo': 99, 'baz': 3}])) == 99
+    assert instance._stat_row_field(max, 'notthere', lambda: [{'foo': 1, 'baz': 3}]) == 0
+    assert instance._stat_row_field(max, 'foo', lambda: [{'foo': 1, 'baz': 3}, {'foo': 99, 'baz': 3}]) == 99

--- a/tests/test_funcs_host.py
+++ b/tests/test_funcs_host.py
@@ -56,8 +56,8 @@ def test_host_select_mac_direction():
     rows = lambda: [{'eth.src': 1, 'eth.dst': 2}, {'eth.src': 2, 'eth.dst': 1}, {'eth.src': 1, 'eth.dst': 99}]
     instance = Host()
     # pytype: disable=attribute-error
-    assert [{'eth.dst': 1, 'eth.src': 2}] == list(instance._select_mac_direction(rows, output=False))
-    assert [{'eth.dst': 2, 'eth.src': 1}, {'eth.dst': 99, 'eth.src': 1}] == list(instance._select_mac_direction(rows, output=True))
+    assert [{'eth.dst': 1, 'eth.src': 2}] == list(instance._select_mac_direction(rows, output=False)())
+    assert [{'eth.dst': 2, 'eth.src': 1}, {'eth.dst': 99, 'eth.src': 1}] == list(instance._select_mac_direction(rows, output=True)())
 
 
 def test_host_max_frame_time():
@@ -75,6 +75,15 @@ def test_host_max_frame_len():
     assert _sort_output(instance.host_tshark_max_frame_len(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'max_frame_len': 999},
         {'host_key': TEST_MAC2, 'max_frame_len': 999}
+    ]
+
+
+def test_host_max_delta_time():
+    instance = Host()
+    rows = [{'frame.time_delta_displayed': 999}]
+    assert _sort_output(instance.host_tshark_max_time_delta(_make_rows_keys(rows, HOST_ROW))) == [
+        {'host_key': TEST_MAC, 'max_time_delta': 999},
+        {'host_key': TEST_MAC2, 'max_time_delta': 999}
     ]
 
 
@@ -206,7 +215,7 @@ def test_host_tcp_priv_ports():
     rows = [{'ip.src': '192.168.0.1', 'tcp.srcport': 1025, 'ip.dst': '192.168.0.2', 'tcp.dstport': 80}, {'ip.src': '192.168.0.1', 'tcp.srcport': 1025, 'ip.dst': '192.168.0.2', 'tcp.dstport': 25}]
     assert _sort_output(instance.host_tshark_priv_tcp_ports_in(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_tcp_priv_port_161_in': 0, 'tshark_tcp_priv_port_67_in': 0, 'tshark_tcp_priv_port_68_in': 0, 'tshark_tcp_priv_port_69_in': 0, 'tshark_tcp_priv_port_631_in': 0, 'tshark_tcp_priv_port_137_in': 0, 'tshark_tcp_priv_port_138_in': 0, 'tshark_tcp_priv_port_139_in': 0, 'tshark_tcp_priv_port_110_in': 0, 'tshark_tcp_priv_port_143_in': 0, 'tshark_tcp_priv_port_80_in': 1, 'tshark_tcp_priv_port_53_in': 0, 'tshark_tcp_priv_port_22_in': 0, 'tshark_tcp_priv_port_23_in': 0, 'tshark_tcp_priv_port_88_in': 0, 'tshark_tcp_priv_port_25_in': 1, 'tshark_tcp_priv_port_443_in': 0, 'tshark_tcp_priv_port_123_in': 0, 'tshark_tcp_priv_port_other_in': 0},
-        {'host_key': TEST_MAC2, 'tshark_tcp_priv_port_161_in': 0, 'tshark_tcp_priv_port_67_in': 0, 'tshark_tcp_priv_port_68_in': 0, 'tshark_tcp_priv_port_69_in': 0, 'tshark_tcp_priv_port_631_in': 0, 'tshark_tcp_priv_port_137_in': 0, 'tshark_tcp_priv_port_138_in': 0, 'tshark_tcp_priv_port_139_in': 0, 'tshark_tcp_priv_port_110_in': 0, 'tshark_tcp_priv_port_143_in': 0, 'tshark_tcp_priv_port_80_in': 0, 'tshark_tcp_priv_port_53_in': 0, 'tshark_tcp_priv_port_22_in': 0, 'tshark_tcp_priv_port_23_in': 0, 'tshark_tcp_priv_port_88_in': 0, 'tshark_tcp_priv_port_25_in': 0, 'tshark_tcp_priv_port_443_in': 0, 'tshark_tcp_priv_port_123_in': 0, 'tshark_tcp_priv_port_other_in': 0},
+        {'host_key': TEST_MAC2, 'tshark_tcp_priv_port_161_in': 0, 'tshark_tcp_priv_port_67_in': 0, 'tshark_tcp_priv_port_68_in': 0, 'tshark_tcp_priv_port_69_in': 0, 'tshark_tcp_priv_port_631_in': 0, 'tshark_tcp_priv_port_137_in': 0, 'tshark_tcp_priv_port_138_in': 0, 'tshark_tcp_priv_port_139_in': 0, 'tshark_tcp_priv_port_110_in': 0, 'tshark_tcp_priv_port_143_in': 0, 'tshark_tcp_priv_port_80_in': 1, 'tshark_tcp_priv_port_53_in': 0, 'tshark_tcp_priv_port_22_in': 0, 'tshark_tcp_priv_port_23_in': 0, 'tshark_tcp_priv_port_88_in': 0, 'tshark_tcp_priv_port_25_in': 1, 'tshark_tcp_priv_port_443_in': 0, 'tshark_tcp_priv_port_123_in': 0, 'tshark_tcp_priv_port_other_in': 0},
     ]
     assert _sort_output(instance.host_tshark_priv_tcp_ports_out(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_tcp_priv_port_161_out': 0, 'tshark_tcp_priv_port_67_out': 0, 'tshark_tcp_priv_port_68_out': 0, 'tshark_tcp_priv_port_69_out': 0, 'tshark_tcp_priv_port_631_out': 0, 'tshark_tcp_priv_port_137_out': 0, 'tshark_tcp_priv_port_138_out': 0, 'tshark_tcp_priv_port_139_out': 0, 'tshark_tcp_priv_port_110_out': 0, 'tshark_tcp_priv_port_143_out': 0, 'tshark_tcp_priv_port_80_out': 0, 'tshark_tcp_priv_port_53_out': 0, 'tshark_tcp_priv_port_22_out': 0, 'tshark_tcp_priv_port_23_out': 0, 'tshark_tcp_priv_port_88_out': 0, 'tshark_tcp_priv_port_25_out': 0, 'tshark_tcp_priv_port_443_out': 0, 'tshark_tcp_priv_port_123_out': 0, 'tshark_tcp_priv_port_other_out': 0},
@@ -219,7 +228,7 @@ def test_host_udp_priv_ports():
     rows = [{'udp.srcport': 1025, 'udp.dstport': 123}]
     assert _sort_output(instance.host_tshark_priv_udp_ports_in(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_udp_priv_port_161_in': 0, 'tshark_udp_priv_port_67_in': 0, 'tshark_udp_priv_port_68_in': 0, 'tshark_udp_priv_port_69_in': 0, 'tshark_udp_priv_port_631_in': 0, 'tshark_udp_priv_port_137_in': 0, 'tshark_udp_priv_port_138_in': 0, 'tshark_udp_priv_port_139_in': 0, 'tshark_udp_priv_port_110_in': 0, 'tshark_udp_priv_port_143_in': 0, 'tshark_udp_priv_port_80_in': 0, 'tshark_udp_priv_port_53_in': 0, 'tshark_udp_priv_port_22_in': 0, 'tshark_udp_priv_port_23_in': 0, 'tshark_udp_priv_port_88_in': 0, 'tshark_udp_priv_port_25_in': 0, 'tshark_udp_priv_port_443_in': 0, 'tshark_udp_priv_port_123_in': 1, 'tshark_udp_priv_port_other_in': 0},
-        {'host_key': TEST_MAC2, 'tshark_udp_priv_port_161_in': 0, 'tshark_udp_priv_port_67_in': 0, 'tshark_udp_priv_port_68_in': 0, 'tshark_udp_priv_port_69_in': 0, 'tshark_udp_priv_port_631_in': 0, 'tshark_udp_priv_port_137_in': 0, 'tshark_udp_priv_port_138_in': 0, 'tshark_udp_priv_port_139_in': 0, 'tshark_udp_priv_port_110_in': 0, 'tshark_udp_priv_port_143_in': 0, 'tshark_udp_priv_port_80_in': 0, 'tshark_udp_priv_port_53_in': 0, 'tshark_udp_priv_port_22_in': 0, 'tshark_udp_priv_port_23_in': 0, 'tshark_udp_priv_port_88_in': 0, 'tshark_udp_priv_port_25_in': 0, 'tshark_udp_priv_port_443_in': 0, 'tshark_udp_priv_port_123_in': 0, 'tshark_udp_priv_port_other_in': 0}
+        {'host_key': TEST_MAC2, 'tshark_udp_priv_port_161_in': 0, 'tshark_udp_priv_port_67_in': 0, 'tshark_udp_priv_port_68_in': 0, 'tshark_udp_priv_port_69_in': 0, 'tshark_udp_priv_port_631_in': 0, 'tshark_udp_priv_port_137_in': 0, 'tshark_udp_priv_port_138_in': 0, 'tshark_udp_priv_port_139_in': 0, 'tshark_udp_priv_port_110_in': 0, 'tshark_udp_priv_port_143_in': 0, 'tshark_udp_priv_port_80_in': 0, 'tshark_udp_priv_port_53_in': 0, 'tshark_udp_priv_port_22_in': 0, 'tshark_udp_priv_port_23_in': 0, 'tshark_udp_priv_port_88_in': 0, 'tshark_udp_priv_port_25_in': 0, 'tshark_udp_priv_port_443_in': 0, 'tshark_udp_priv_port_123_in': 1, 'tshark_udp_priv_port_other_in': 0}
     ]
     assert _sort_output(instance.host_tshark_priv_udp_ports_out(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_udp_priv_port_161_out': 0, 'tshark_udp_priv_port_67_out': 0, 'tshark_udp_priv_port_68_out': 0, 'tshark_udp_priv_port_69_out': 0, 'tshark_udp_priv_port_631_out': 0, 'tshark_udp_priv_port_137_out': 0, 'tshark_udp_priv_port_138_out': 0, 'tshark_udp_priv_port_139_out': 0, 'tshark_udp_priv_port_110_out': 0, 'tshark_udp_priv_port_143_out': 0, 'tshark_udp_priv_port_80_out': 0, 'tshark_udp_priv_port_53_out': 0, 'tshark_udp_priv_port_22_out': 0, 'tshark_udp_priv_port_23_out': 0, 'tshark_udp_priv_port_88_out': 0, 'tshark_udp_priv_port_25_out': 0, 'tshark_udp_priv_port_443_out': 0, 'tshark_udp_priv_port_123_out': 0, 'tshark_udp_priv_port_other_out': 0},
@@ -232,7 +241,7 @@ def test_host_tcp_nonpriv_ports():
     rows = [{'tcp.srcport': 1025, 'tcp.dstport': 9999}]
     assert _sort_output(instance.host_tshark_nonpriv_tcp_ports_in(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_tcp_nonpriv_port_5349_in': 0, 'tshark_tcp_nonpriv_port_5222_in': 0, 'tshark_tcp_nonpriv_port_2375_in': 0, 'tshark_tcp_nonpriv_port_2376_in': 0, 'tshark_tcp_nonpriv_port_5353_in': 0, 'tshark_tcp_nonpriv_port_5354_in': 0, 'tshark_tcp_nonpriv_port_1900_in': 0, 'tshark_tcp_nonpriv_port_5357_in': 0, 'tshark_tcp_nonpriv_port_6653_in': 0, 'tshark_tcp_nonpriv_port_other_in': 1},
-        {'host_key': TEST_MAC2, 'tshark_tcp_nonpriv_port_5349_in': 0, 'tshark_tcp_nonpriv_port_5222_in': 0, 'tshark_tcp_nonpriv_port_2375_in': 0, 'tshark_tcp_nonpriv_port_2376_in': 0, 'tshark_tcp_nonpriv_port_5353_in': 0, 'tshark_tcp_nonpriv_port_5354_in': 0, 'tshark_tcp_nonpriv_port_1900_in': 0, 'tshark_tcp_nonpriv_port_5357_in': 0, 'tshark_tcp_nonpriv_port_6653_in': 0, 'tshark_tcp_nonpriv_port_other_in': 0}
+        {'host_key': TEST_MAC2, 'tshark_tcp_nonpriv_port_5349_in': 0, 'tshark_tcp_nonpriv_port_5222_in': 0, 'tshark_tcp_nonpriv_port_2375_in': 0, 'tshark_tcp_nonpriv_port_2376_in': 0, 'tshark_tcp_nonpriv_port_5353_in': 0, 'tshark_tcp_nonpriv_port_5354_in': 0, 'tshark_tcp_nonpriv_port_1900_in': 0, 'tshark_tcp_nonpriv_port_5357_in': 0, 'tshark_tcp_nonpriv_port_6653_in': 0, 'tshark_tcp_nonpriv_port_other_in': 1}
     ]
     assert _sort_output(instance.host_tshark_nonpriv_tcp_ports_out(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_tcp_nonpriv_port_5349_out': 0, 'tshark_tcp_nonpriv_port_5222_out': 0, 'tshark_tcp_nonpriv_port_2375_out': 0, 'tshark_tcp_nonpriv_port_2376_out': 0, 'tshark_tcp_nonpriv_port_5353_out': 0, 'tshark_tcp_nonpriv_port_5354_out': 0, 'tshark_tcp_nonpriv_port_1900_out': 0, 'tshark_tcp_nonpriv_port_5357_out': 0, 'tshark_tcp_nonpriv_port_6653_out': 0, 'tshark_tcp_nonpriv_port_other_out': 0},
@@ -245,7 +254,7 @@ def test_host_udp_nonpriv_ports():
     rows = [{'udp.srcport': 1025, 'udp.dstport': 9999}]
     assert _sort_output(instance.host_tshark_nonpriv_udp_ports_in(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_udp_nonpriv_port_5349_in': 0, 'tshark_udp_nonpriv_port_5222_in': 0, 'tshark_udp_nonpriv_port_2375_in': 0, 'tshark_udp_nonpriv_port_2376_in': 0, 'tshark_udp_nonpriv_port_5353_in': 0, 'tshark_udp_nonpriv_port_5354_in': 0, 'tshark_udp_nonpriv_port_1900_in': 0, 'tshark_udp_nonpriv_port_5357_in': 0, 'tshark_udp_nonpriv_port_6653_in': 0, 'tshark_udp_nonpriv_port_other_in': 1},
-        {'host_key': TEST_MAC2, 'tshark_udp_nonpriv_port_5349_in': 0, 'tshark_udp_nonpriv_port_5222_in': 0, 'tshark_udp_nonpriv_port_2375_in': 0, 'tshark_udp_nonpriv_port_2376_in': 0, 'tshark_udp_nonpriv_port_5353_in': 0, 'tshark_udp_nonpriv_port_5354_in': 0, 'tshark_udp_nonpriv_port_1900_in': 0, 'tshark_udp_nonpriv_port_5357_in': 0, 'tshark_udp_nonpriv_port_6653_in': 0, 'tshark_udp_nonpriv_port_other_in': 0}
+        {'host_key': TEST_MAC2, 'tshark_udp_nonpriv_port_5349_in': 0, 'tshark_udp_nonpriv_port_5222_in': 0, 'tshark_udp_nonpriv_port_2375_in': 0, 'tshark_udp_nonpriv_port_2376_in': 0, 'tshark_udp_nonpriv_port_5353_in': 0, 'tshark_udp_nonpriv_port_5354_in': 0, 'tshark_udp_nonpriv_port_1900_in': 0, 'tshark_udp_nonpriv_port_5357_in': 0, 'tshark_udp_nonpriv_port_6653_in': 0, 'tshark_udp_nonpriv_port_other_in': 1}
     ]
     assert _sort_output(instance.host_tshark_nonpriv_udp_ports_out(_make_rows_keys(rows, HOST_ROW))) == [
         {'host_key': TEST_MAC, 'tshark_udp_nonpriv_port_5349_out': 0, 'tshark_udp_nonpriv_port_5222_out': 0, 'tshark_udp_nonpriv_port_2375_out': 0, 'tshark_udp_nonpriv_port_2376_out': 0, 'tshark_udp_nonpriv_port_5353_out': 0, 'tshark_udp_nonpriv_port_5354_out': 0, 'tshark_udp_nonpriv_port_1900_out': 0, 'tshark_udp_nonpriv_port_5357_out': 0, 'tshark_udp_nonpriv_port_6653_out': 0, 'tshark_udp_nonpriv_port_other_out': 0},


### PR DESCRIPTION
Ensure generators aren't expired (ie. that a generator that produced rows for a variable produces rows again).
Arrange featurizer calls to hit float field cache as much as possible.